### PR TITLE
Fix 3.18.1 build

### DIFF
--- a/debian/libgpsLIBGPSSONAME.install
+++ b/debian/libgpsLIBGPSSONAME.install
@@ -1,2 +1,1 @@
-usr/lib/*/libgps.so.LIBGPSSONAME
 usr/lib/*/libgps.so.LIBGPSSONAME.*

--- a/debian/libgpsLIBGPSSONAME.install
+++ b/debian/libgpsLIBGPSSONAME.install
@@ -1,2 +1,2 @@
-usr/lib/*/libg*.so.*
-usr/lib/*/libg*.so.*.*
+usr/lib/*/libgps.so.LIBGPSSONAME
+usr/lib/*/libgps.so.LIBGPSSONAME.*

--- a/debian/rules
+++ b/debian/rules
@@ -179,6 +179,10 @@ install-stamp: build-stamp build-static-stamp $(LIBGPS_DEBIAN_FILE_TARGETS)
 	mv -v debian/tmp/usr/local/lib/* debian/tmp/usr/lib/
 	# install everything
 	dh_install
+	# quirk to avoid issues by broken fakeroot misdetecting links as files and
+	# then breaking dh_install -> cp -a fatally
+	ln -s libgps.so.24.0.0 debian/libgps24/usr/lib/$(DEB_HOST_MULTIARCH)/libgps.so.24
+	rm debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/libgps.so.24
 	dh_missing --fail-missing
 	# remove rpaths
 	find debian -type f -exec file {} \; |\

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: check-service
-Depends: gpsd
+Depends: gpsd, systemd, grep, coreutils, telnet
 Restrictions: needs-root, isolation-container

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: check-service
 Depends: gpsd
-Restrictions: needs-root
+Restrictions: needs-root, isolation-container


### PR DESCRIPTION
A few issues with the Tests were mentioned, this should fix them.
Also all install files follow the LIBGPSSONAME rename, lets do the same for libgps itself as well.