### PR TITLE
d/usr.sbin.gpsd: Relicense to BSD to match the Project

### DIFF
--- a/debian/usr.sbin.gpsd
+++ b/debian/usr.sbin.gpsd
@@ -1,11 +1,10 @@
 # vim:syntax=apparmor
 # ------------------------------------------------------------------
 #
-#    Copyright (C) 2018 Canonical Ltd.
+# Copyright (C) 2018 Canonical Ltd.
 #
-#    This program is free software; you can redistribute it and/or
-#    modify it under the terms of version 2 of the GNU General Public
-#    License published by the Free Software Foundation.
+# This software is distributed under a BSD-style license. See the
+# file "COPYING" in the top-level directory of the distribution for details.
 #
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
As the Author of the profile I'm relicensing the apparmor profile
to the BSD License to match the (majority) of the rest of the
GPSD project licenses.

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>