### PR TITLE
Allow gpsd.service to be enabled by the admin at boot time.

### DIFF
--- a/debian/patches/full-systemd-support
+++ b/debian/patches/full-systemd-support
@@ -1,6 +1,6 @@
 --- a/systemd/gpsd.service
 +++ b/systemd/gpsd.service
-@@ -7,9 +7,7 @@ After=chronyd.service
+@@ -7,8 +7,7 @@ After=chronyd.service
  [Service]
  Type=forking
  EnvironmentFile=-/etc/default/gpsd
@@ -9,5 +9,4 @@
 +ExecStart=/usr/sbin/gpsd $GPSD_OPTIONS $DEVICES
  
  [Install]
--WantedBy=multi-user.target
- Also=gpsd.socket
+ WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -190,7 +190,8 @@ binary: install-stamp
 	dh_installdocs 
 	dh_installman 
 	dh_installmenu 
-	dh_systemd_enable -pgpsd
+	dh_installsystemd -pgpsd --restart-after-upgrade gpsdctl@.service gpsd.socket
+	dh_installsystemd -pgpsd --no-enable --no-start gpsd.service
 	dh_installinit
 	dh_systemd_start -pgpsd --restart-after-upgrade
 	dh_installexamples 


### PR DESCRIPTION
Be sure to keep it disabled. The admin needs to explicitly start it if needed.

*Please* wait for my follow up mail on the Debian bug.